### PR TITLE
Fixed docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/IFC.js"]
-	path = docs/IFC.js
-	url = git@github.com:IFCjs/docs.git

--- a/README.md
+++ b/README.md
@@ -16,12 +16,5 @@ Start the Flask backend server:
 cd api/ && flask run
 ```
 
-## How to read the docs?
-### IFC.js docs
-`cd docs/IFC.js && npm run serve`
-
-Start the VueJs frontend development server:
-```bash
-cd webapp/ && npm install && npm run dev
-```
-
+## Docs
+[IFC.js](https://docs.thatopen.com/Tutorials/FragmentIfcLoader)


### PR DESCRIPTION
Removed local static IFC.js docs and added a link to the online resource instead.

A better structure is kept at this repository.